### PR TITLE
Support dumping Seqs of values

### DIFF
--- a/src/main/scala/Dump.scala
+++ b/src/main/scala/Dump.scala
@@ -5,6 +5,11 @@ import scala.collection.mutable
 object Dump {
   def apply[T](key:Any,value:T):T = ParameterDump.apply(key, value)
   def apply[T](knob:Knob[T]):Knob[T] = ParameterDump.apply(knob)
+  def apply[T](key_base:String,values:Seq[T]):Seq[T] = {
+    values.zipWithIndex.foreach{ case(value, i) => Dump(key_base + "__" + i, value) }
+    Dump(key_base + "__COUNT", values.size)
+    values
+  }
 }
 
 object ParameterDump {


### PR DESCRIPTION
I want to be able to dump a Seq of values that I can then process in the C test
harness.  This patch dumps each element of the array as a seperate #define,
along with a "__COUNT" at the end.  This format is amenable to processing with
C preprocessor repat macros.
