### PR TITLE
Improve performance and make CDEMatchError mirror MatchError

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -1,9 +1,9 @@
 package cde
 
 class Config(
-  val topDefinitions: World.TopDefs = { (a,b,c) => {throw new scala.MatchError(a)}},
+  val topDefinitions: World.TopDefs = { (a,b,c) => throw new CDEMatchError(a) },
   val topConstraints: List[ViewSym=>Ex[Boolean]] = List( ex => ExLit[Boolean](true) ),
-  val knobValues: Any=>Any = { case x => {throw new scala.MatchError(x)}}
+  val knobValues: Any => Any = { case x => throw new CDEMatchError(x) }
 ) {
   import Implicits._
   type Constraint = ViewSym=>Ex[Boolean]

--- a/src/main/scala/Parameters.scala
+++ b/src/main/scala/Parameters.scala
@@ -6,8 +6,25 @@ import scala.collection.mutable
 // Convention: leading _'s on names means private to the outside world
 // but accessible to anything in this file.
 
-class CDEMatchError() extends Exception {
+/** Custom "MatchError" to improve performance of CDE
+  * Mirrors [[scala.MatchError]]
+  */
+final class CDEMatchError(obj: Any = null) extends Exception {
   override def fillInStackTrace() = this
+
+  // Borrowed from scala.MatchError
+  // lazy so that objString is only created upon calling getMessage
+  private lazy val objString = {
+    def ofClass = "of class " + obj.getClass.getName
+    if (obj == null) "null"
+    else try {
+      obj.toString + " (" + ofClass + ")"
+    } catch {
+      case _: Throwable => "an instance " + ofClass
+    }
+  }
+
+  override def getMessage = objString
 }
 
 class ParameterUndefinedException(field:Any, cause:Throwable=null)


### PR DESCRIPTION
Change top-level configs to throw CDEMatchErrors instead of MatchError
Add optional argument to CDEMatchError so it can be used exactly like MatchError

Unscientifically, this improves performance on rocket-chip with rocket as core by ~30%
